### PR TITLE
fix: use token from context

### DIFF
--- a/src/modules/Root.tsx
+++ b/src/modules/Root.tsx
@@ -75,6 +75,9 @@ const RootDiv = styled('div')({
 const Root: FC = () => {
   const [mockContext, setMockContext] = useObjectState(defaultMockContext);
 
+  // eslint-disable-next-line no-console
+  console.log('render root');
+
   return (
     <RootDiv>
       {/* Used to define the order of injected properties between JSS and emotion */}

--- a/src/modules/builder/configuration/AddImageStep.tsx
+++ b/src/modules/builder/configuration/AddImageStep.tsx
@@ -9,6 +9,8 @@ import {
   Typography,
 } from '@mui/material';
 
+import { TokenContext, useLocalContext } from '@graasp/apps-query-client';
+
 import { Settings, SettingsKeys } from '@/@types';
 import { useAppTranslation } from '@/config/i18n';
 import { hooks } from '@/config/queryClient';
@@ -23,6 +25,8 @@ type Props = {
 };
 const AddImageStep = ({ moveToNextStep }: Props): JSX.Element => {
   const { t } = useAppTranslation();
+  const { itemId } = useLocalContext();
+  const token = useContext(TokenContext);
   const { data: imageSetting } = hooks.useAppSettings({
     name: SettingsKeys.File,
   });
@@ -83,7 +87,9 @@ const AddImageStep = ({ moveToNextStep }: Props): JSX.Element => {
           <Typography variant="body2" color="grey">
             {t(APP.DROP_IMAGE_DESCRIPTION)}
           </Typography>
-          <UploadImage />
+          {Boolean(token && itemId) && (
+            <UploadImage token={token} itemId={itemId} />
+          )}
         </Box>
       )}
       <Box alignSelf="end">

--- a/src/modules/common/UploadImage.tsx
+++ b/src/modules/common/UploadImage.tsx
@@ -1,79 +1,30 @@
-import { useContext, useEffect, useState } from 'react';
-
 import { Box } from '@mui/material';
 
-import {
-  ROUTINES,
-  TokenContext,
-  useLocalContext,
-} from '@graasp/apps-query-client';
-
-import Uppy, { UploadResult } from '@uppy/core';
 import '@uppy/core/dist/style.css';
 import '@uppy/dashboard/dist/style.css';
 import { Dashboard } from '@uppy/react';
 
 import { FILE_UPLOAD_MAX_FILES } from '@/config/constants';
 import { useAppTranslation } from '@/config/i18n';
-import { mutations, notifier } from '@/config/queryClient';
 import { APP } from '@/langs/constants';
-import configureUppy from '@/utils/uppy';
+import { useUploadImage } from '@/utils/hooks';
 
 import { DASHBOARD_UPLOADER_ID } from '../../config/selectors';
 
-const { uploadAppSettingFileRoutine } = ROUTINES;
 type Props = {
+  itemId: string;
+  token: string;
   onUploadComplete?: () => void;
 };
 
-const UploadImage = ({ onUploadComplete }: Props): JSX.Element | null => {
+const UploadImage = ({
+  onUploadComplete,
+  itemId,
+  token,
+}: Props): JSX.Element | null => {
   const { t } = useAppTranslation();
 
-  const { itemId, apiHost } = useLocalContext();
-  const token = useContext(TokenContext);
-  const [uppy, setUppy] = useState<Uppy | null>(null);
-  const { mutate: onFileUploadComplete } = mutations.useUploadAppSettingFile();
-
-  const onComplete = (result: UploadResult): boolean | void => {
-    if (!result?.failed.length) {
-      onFileUploadComplete({
-        data: result.successful
-          ?.map(({ response }) => response?.body?.[0])
-          .filter(Boolean),
-      });
-      onUploadComplete?.();
-    }
-    return false;
-  };
-
-  const onUpload = (): void => {
-    notifier({ type: uploadAppSettingFileRoutine.SUCCESS });
-  };
-
-  const onError = (error: Error): void => {
-    onFileUploadComplete({ error });
-  };
-
-  // update uppy configuration each time itemId changes
-  useEffect(() => {
-    if (typeof token !== 'undefined') {
-      setUppy(
-        configureUppy({
-          apiHost,
-          itemId,
-          token,
-          onComplete,
-          onError,
-          onUpload,
-        }),
-      );
-    }
-
-    return () => {
-      uppy?.close();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const uppy = useUploadImage({ itemId, token, onUploadComplete });
 
   if (!uppy) {
     return null;

--- a/src/modules/common/UploadImage.tsx
+++ b/src/modules/common/UploadImage.tsx
@@ -1,16 +1,27 @@
+import { useContext, useEffect, useState } from 'react';
+
 import { Box } from '@mui/material';
 
+import {
+  ROUTINES,
+  TokenContext,
+  useLocalContext,
+} from '@graasp/apps-query-client';
+
+import Uppy, { UploadResult } from '@uppy/core';
 import '@uppy/core/dist/style.css';
 import '@uppy/dashboard/dist/style.css';
 import { Dashboard } from '@uppy/react';
 
 import { FILE_UPLOAD_MAX_FILES } from '@/config/constants';
 import { useAppTranslation } from '@/config/i18n';
+import { mutations, notifier } from '@/config/queryClient';
 import { APP } from '@/langs/constants';
-import { useUploadImage } from '@/utils/hooks';
+import configureUppy from '@/utils/uppy';
 
 import { DASHBOARD_UPLOADER_ID } from '../../config/selectors';
 
+const { uploadAppSettingFileRoutine } = ROUTINES;
 type Props = {
   onUploadComplete?: () => void;
 };
@@ -18,7 +29,51 @@ type Props = {
 const UploadImage = ({ onUploadComplete }: Props): JSX.Element | null => {
   const { t } = useAppTranslation();
 
-  const uppy = useUploadImage({ onUploadComplete });
+  const { itemId, apiHost } = useLocalContext();
+  const token = useContext(TokenContext);
+  const [uppy, setUppy] = useState<Uppy | null>(null);
+  const { mutate: onFileUploadComplete } = mutations.useUploadAppSettingFile();
+
+  const onComplete = (result: UploadResult): boolean | void => {
+    if (!result?.failed.length) {
+      onFileUploadComplete({
+        data: result.successful
+          ?.map(({ response }) => response?.body?.[0])
+          .filter(Boolean),
+      });
+      onUploadComplete?.();
+    }
+    return false;
+  };
+
+  const onUpload = (): void => {
+    notifier({ type: uploadAppSettingFileRoutine.SUCCESS });
+  };
+
+  const onError = (error: Error): void => {
+    onFileUploadComplete({ error });
+  };
+
+  // update uppy configuration each time itemId changes
+  useEffect(() => {
+    if (typeof token !== 'undefined') {
+      setUppy(
+        configureUppy({
+          apiHost,
+          itemId,
+          token,
+          onComplete,
+          onError,
+          onUpload,
+        }),
+      );
+    }
+
+    return () => {
+      uppy?.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemId, token]);
 
   if (!uppy) {
     return null;

--- a/src/modules/common/UploadImage.tsx
+++ b/src/modules/common/UploadImage.tsx
@@ -73,7 +73,7 @@ const UploadImage = ({ onUploadComplete }: Props): JSX.Element | null => {
       uppy?.close();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemId, token]);
+  }, []);
 
   if (!uppy) {
     return null;

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,10 +1,6 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import {
-  ROUTINES,
-  TokenContext,
-  useLocalContext,
-} from '@graasp/apps-query-client';
+import { ROUTINES, useLocalContext } from '@graasp/apps-query-client';
 
 import Uppy, { UploadResult } from '@uppy/core';
 
@@ -49,11 +45,16 @@ const { uploadAppSettingFileRoutine } = ROUTINES;
 
 type Props = {
   onUploadComplete?: () => void;
+  itemId: string;
+  token: string;
 };
 
-export const useUploadImage = ({ onUploadComplete }: Props): Uppy | null => {
-  const { itemId, apiHost } = useLocalContext();
-  const token = useContext(TokenContext);
+export const useUploadImage = ({
+  onUploadComplete,
+  token,
+  itemId,
+}: Props): Uppy | null => {
+  const { apiHost } = useLocalContext();
   const [uppy, setUppy] = useState<Uppy | null>(null);
   const { mutate: onFileUploadComplete } = mutations.useUploadAppSettingFile();
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,10 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
-import { ROUTINES, useLocalContext } from '@graasp/apps-query-client';
+import {
+  ROUTINES,
+  TokenContext,
+  useLocalContext,
+} from '@graasp/apps-query-client';
 
 import Uppy, { UploadResult } from '@uppy/core';
 
-import { hooks, mutations, notifier } from '@/config/queryClient';
+import { mutations, notifier } from '@/config/queryClient';
 
 import configureUppy from './uppy';
 
@@ -49,7 +53,7 @@ type Props = {
 
 export const useUploadImage = ({ onUploadComplete }: Props): Uppy | null => {
   const { itemId, apiHost } = useLocalContext();
-  const { data: token } = hooks.useAuthToken(itemId);
+  const token = useContext(TokenContext);
   const [uppy, setUppy] = useState<Uppy | null>(null);
   const { mutate: onFileUploadComplete } = mutations.useUploadAppSettingFile();
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -78,7 +78,8 @@ export const useUploadImage = ({
     onFileUploadComplete({ error });
   };
 
-  const applyUppy = (): void => {
+  // update uppy configuration each time itemId changes
+  useEffect(() => {
     if (typeof token !== 'undefined') {
       setUppy(
         configureUppy({
@@ -91,17 +92,12 @@ export const useUploadImage = ({
         }),
       );
     }
-  };
-
-  // update uppy configuration each time itemId changes
-  useEffect(() => {
-    applyUppy();
 
     return () => {
       uppy?.close();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemId, token]);
+  }, []);
 
   return uppy;
 };

--- a/src/utils/uppy.ts
+++ b/src/utils/uppy.ts
@@ -57,30 +57,30 @@ const configureUppy = ({
     },
   });
 
-  // uppy.on('file-added', (file) => {
-  //   onFileAdded?.(file);
-  // });
+  uppy.on('file-added', (file) => {
+    onFileAdded?.(file);
+  });
 
-  // uppy.on('files-added', (files) => {
-  //   onFilesAdded?.(files);
-  // });
+  uppy.on('files-added', (files) => {
+    onFilesAdded?.(files);
+  });
 
-  // uppy.on('upload', onUpload);
+  uppy.on('upload', onUpload);
 
-  // if (onProgress) {
-  //   uppy.on('progress', onProgress);
-  // }
+  if (onProgress) {
+    uppy.on('progress', onProgress);
+  }
 
-  // uppy.on('complete', (result) => {
-  //   onComplete?.(result);
-  // });
+  uppy.on('complete', (result) => {
+    onComplete?.(result);
+  });
 
-  // if (onError) {
-  //   uppy.on('error', onError);
-  //   uppy.on('upload-error', (_, error) => {
-  //     onError(error);
-  //   });
-  // }
+  if (onError) {
+    uppy.on('error', onError);
+    uppy.on('upload-error', (_, error) => {
+      onError(error);
+    });
+  }
 
   return uppy;
 };

--- a/src/utils/uppy.ts
+++ b/src/utils/uppy.ts
@@ -57,30 +57,30 @@ const configureUppy = ({
     },
   });
 
-  uppy.on('file-added', (file) => {
-    onFileAdded?.(file);
-  });
+  // uppy.on('file-added', (file) => {
+  //   onFileAdded?.(file);
+  // });
 
-  uppy.on('files-added', (files) => {
-    onFilesAdded?.(files);
-  });
+  // uppy.on('files-added', (files) => {
+  //   onFilesAdded?.(files);
+  // });
 
-  uppy.on('upload', onUpload);
+  // uppy.on('upload', onUpload);
 
-  if (onProgress) {
-    uppy.on('progress', onProgress);
-  }
+  // if (onProgress) {
+  //   uppy.on('progress', onProgress);
+  // }
 
-  uppy.on('complete', (result) => {
-    onComplete?.(result);
-  });
+  // uppy.on('complete', (result) => {
+  //   onComplete?.(result);
+  // });
 
-  if (onError) {
-    uppy.on('error', onError);
-    uppy.on('upload-error', (_, error) => {
-      onError(error);
-    });
-  }
+  // if (onError) {
+  //   uppy.on('error', onError);
+  //   uppy.on('upload-error', (_, error) => {
+  //     onError(error);
+  //   });
+  // }
 
   return uppy;
 };

--- a/src/utils/uppy.ts
+++ b/src/utils/uppy.ts
@@ -44,7 +44,7 @@ const configureUppy = ({
       maxNumberOfFiles: FILE_UPLOAD_MAX_FILES,
       allowedFileTypes: ['image/*'], // Allow only images
     },
-    autoProceed: false,
+    autoProceed: true,
   });
 
   uppy.use(XHRUpload, {


### PR DESCRIPTION
I've fixed the upload image re-render.

Actually I think the source problem is still there, because the api access token is still requested when you upload. But I couldn't find why. Maybe an incompatibility between uppy and our setup? I was wondering if `useAutoResize` would reload the content? SInce adding the image changes the app size. @spaenleh 

What I do instead is setup uppy only if the token and item id are defined, so we avoid `useEffect` with token in it. Having `autoProceed` enabled or not doesn't change anything, but I've enabled it since I didn't see the purpose of preventing automatic upload.