### PR TITLE
fix: refactor and better use beautiful dnd

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -27,7 +27,7 @@ export type AnsweredLabel = {
 
 export type SubmittedAnswer = {
   expectedId: string;
-  actualId?: string;
+  actualId?: string | null;
 };
 
 type Answer = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -33,8 +33,7 @@ if (MOCK_API) {
   );
 }
 
+// cannot use strict because of beautiful-dnd
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <Root />
-  </React.StrictMode>,
+  <Root />,
 );

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -131,8 +131,18 @@ const buildDatabase = (): Database => ({
       data: {
         description: '',
         labels: [
-          { content: 'content', id: 'id' },
-          { content: 'content1', id: 'id1' },
+          {
+            content: 'content',
+            id: 'id',
+            x: '40.09919261822376%',
+            y: '17.26830060055186%',
+          },
+          {
+            content: 'content1',
+            id: 'id1',
+            x: '62.09919261822376%',
+            y: '47.26830060055186%',
+          },
         ],
       },
       updatedAt: new Date().toISOString(),

--- a/src/modules/common/AllLabelsContainer.tsx
+++ b/src/modules/common/AllLabelsContainer.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { Droppable } from 'react-beautiful-dnd';
 
-import { styled } from '@mui/material';
+import { Stack, styled } from '@mui/material';
 
 import { Label } from '@/@types';
 import {
@@ -11,28 +10,30 @@ import {
 
 import DraggableLabel from './DraggableLabelToDroppableCont';
 
-export const StyledBox = styled('div')<{
+export const StyledBox = styled(Stack)<{
   isDraggingOver: boolean;
 }>(({ theme, isDraggingOver }) => ({
-  display: 'flex',
-  gap: theme.spacing(1),
-  flexWrap: 'wrap',
   borderRadius: theme.spacing(1),
   background: isDraggingOver ? 'lightgray' : 'white',
   width: '100%',
-  minHeight: '40px',
-  padding: '2px',
   border: '1px solid black',
+  minHeight: '40px',
 }));
 
 type Props = {
   labels: Label[];
+  isSubmitted?: boolean;
 };
 
-const AllLabelsContainer = ({ labels }: Props): JSX.Element => (
-  <Droppable droppableId={ALL_DROPPABLE_CONTAINER_ID}>
+const AllLabelsContainer = ({ labels, isSubmitted }: Props): JSX.Element => (
+  <Droppable
+    key={ALL_DROPPABLE_CONTAINER_ID}
+    droppableId={ALL_DROPPABLE_CONTAINER_ID}
+    direction="horizontal"
+  >
     {(provided, dropSnapshot) => (
       <StyledBox
+        direction="row"
         ref={provided.innerRef}
         {...provided.droppableProps}
         isDraggingOver={dropSnapshot.isDraggingOver}
@@ -44,6 +45,7 @@ const AllLabelsContainer = ({ labels }: Props): JSX.Element => (
             draggableId={item?.id}
             index={index}
             key={item?.id}
+            isSubmitted={isSubmitted}
           />
         ))}
         {provided.placeholder}

--- a/src/modules/common/DraggableFrameWithLabels.tsx
+++ b/src/modules/common/DraggableFrameWithLabels.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch';
 
 import { Box, styled } from '@mui/material';
@@ -48,8 +47,9 @@ const DraggableFrameWithLabels = ({
       >
         <Box sx={{ width: '100%' }} id={LABELS_WITHIN_FRAME_CONTAINER_ID}>
           <ImageFrame />
-          {labels.map((label) => (
+          {labels.map((label, index) => (
             <DroppableLabel
+              index={index}
               label={label}
               key={label.expected.id}
               isDragging={isDragging}

--- a/src/modules/common/DraggableLabelToDroppableCont.tsx
+++ b/src/modules/common/DraggableLabelToDroppableCont.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 
 import { styled } from '@mui/material';
@@ -12,14 +11,10 @@ export const StyledLabel = styled('div')<{
 }>(({ theme, isDraggable, isSubmitted, isCorrect }) => ({
   color: 'white',
   borderRadius: theme.spacing(1),
-  gap: theme.spacing(1),
-  userSelect: 'none',
   border: '1px solid white',
-  padding: theme.spacing(0.5),
+  padding: theme.spacing(1),
   ...(isDraggable
     ? {
-        left: 'initial !important',
-        top: 'initial !important',
         background: 'purple',
       }
     : {
@@ -46,7 +41,12 @@ const DraggableLabelToDroppableCont = ({
   isSubmitted = false,
   isCorrect,
 }: Props): JSX.Element => (
-  <Draggable draggableId={draggableId} index={index}>
+  <Draggable
+    key={draggableId}
+    draggableId={draggableId}
+    index={index}
+    isDragDisabled={isSubmitted}
+  >
     {(dragProvided, dragSnapshot) => (
       <StyledLabel
         ref={dragProvided.innerRef}

--- a/src/modules/common/DroppableLabel.tsx
+++ b/src/modules/common/DroppableLabel.tsx
@@ -40,14 +40,16 @@ type Props = {
   label: AnsweredLabel;
   isDragging?: boolean;
   isSubmitted: boolean;
+  index: number;
 };
 
 const DroppableLabel = ({
   label,
   isDragging,
   isSubmitted,
+  index,
 }: Props): JSX.Element => (
-  <Droppable droppableId={label.expected.id}>
+  <Droppable droppableId={label.expected.id} key={label.expected.id}>
     {(provided, dropSnapshot) => (
       <Wrapper
         ref={provided.innerRef}
@@ -59,15 +61,15 @@ const DroppableLabel = ({
         isDragging={isDragging}
         id={buildDraggableLabelId(label.expected.id)}
       >
-        {label.actual && (
+        {label.actual ? (
           <DraggableLabelToDroppableCont
             isCorrect={label.expected.id === label.actual?.id}
             isSubmitted={isSubmitted}
             content={label.actual.content}
-            index={0}
+            index={index}
             draggableId={label.actual.id}
           />
-        )}
+        ) : null}
         {provided.placeholder}
       </Wrapper>
     )}

--- a/src/modules/common/PlayerFrame.tsx
+++ b/src/modules/common/PlayerFrame.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 
 import { Box, Typography } from '@mui/material';
@@ -68,7 +68,7 @@ const PlayerFrame = ({
               width: '100%',
             }}
           >
-            <AllLabelsContainer labels={labels} />
+            <AllLabelsContainer labels={labels} isSubmitted={isSubmitted} />
           </Box>
         )}
         <DraggableFrameWithLabels


### PR DESCRIPTION
Removed `useState` - the impact of this is that the app always updates the app data on dropping a label.

A last remaining glitch is induced by the transform element. It's maybe possible to cancel the changes on wanted elements, but that's for another PR.

TODO:
- [x] patch app data instead of saving a new one each time

fix #197