### PR TITLE
fix: allow delete a label in frame

### DIFF
--- a/cypress/fixtures/mockItem.ts
+++ b/cypress/fixtures/mockItem.ts
@@ -3,7 +3,7 @@ import { AppItemExtra, ItemType } from '@graasp/sdk';
 import { MEMBERS } from './members';
 
 export const MOCK_SERVER_ITEM = {
-  id: '123456789',
+  id: '7f165691-6fa8-4712-b4b8-63aa0fdf91ed',
   name: 'app-starter-ts-vite',
   displayName: 'app-starter-ts-vite',
   description: null,

--- a/src/modules/builder/configuration/PreviewStep.tsx
+++ b/src/modules/builder/configuration/PreviewStep.tsx
@@ -43,6 +43,18 @@ const PreviewStep = (): JSX.Element => {
     setAnsweredLabels(newAnswers);
   };
 
+  const onRemoveLabel = (label: Label): void => {
+    const newAnsweredLabels = answeredLabels.map((a) => {
+      if (a?.actual?.id === label.id) {
+        return { ...a, actual: null };
+      }
+      return a;
+    });
+
+    setLabels(labels.concat([label]));
+    setAnsweredLabels(newAnsweredLabels);
+  };
+
   return (
     <>
       <Alert severity="success">{t(APP.PREVIEW_NOTE)}</Alert>
@@ -56,6 +68,7 @@ const PreviewStep = (): JSX.Element => {
           labels={labels}
           answeredLabels={answeredLabels}
           onLabelMoved={onLabelMoved}
+          onRemoveLabel={onRemoveLabel}
         />
         <Stack direction="row" gap={1} width="100%" justifyContent="flex-end">
           <Button

--- a/src/modules/common/AllLabelsContainer.tsx
+++ b/src/modules/common/AllLabelsContainer.tsx
@@ -8,7 +8,7 @@ import {
   ALL_LABELS_CONTAINER_ID,
 } from '@/config/selectors';
 
-import DraggableLabel from './DraggableLabelToDroppableCont';
+import DraggableLabelToDroppableCont from './DraggableLabelToDroppableCont';
 
 export const StyledBox = styled(Stack)<{
   isDraggingOver: boolean;
@@ -39,12 +39,12 @@ const AllLabelsContainer = ({ labels, isSubmitted }: Props): JSX.Element => (
         isDraggingOver={dropSnapshot.isDraggingOver}
         id={ALL_LABELS_CONTAINER_ID}
       >
-        {labels.map((item, index) => (
-          <DraggableLabel
-            content={item.content}
-            draggableId={item?.id}
+        {labels.map((l, index) => (
+          <DraggableLabelToDroppableCont
+            content={l.content}
+            label={l}
             index={index}
-            key={item?.id}
+            key={l.id}
             isSubmitted={isSubmitted}
           />
         ))}

--- a/src/modules/common/DraggableFrameWithLabels.tsx
+++ b/src/modules/common/DraggableFrameWithLabels.tsx
@@ -5,6 +5,7 @@ import { Box, styled } from '@mui/material';
 import { AnsweredLabel } from '@/@types';
 import { LABELS_WITHIN_FRAME_CONTAINER_ID } from '@/config/selectors';
 
+import { DraggableLabelToDroppableContProps } from './DraggableLabelToDroppableCont';
 import DroppableLabel from './DroppableLabel';
 import ImageFrame from './ImageFrame';
 
@@ -12,6 +13,7 @@ type Props = {
   isDragging: boolean;
   isSubmitted: boolean;
   labels: AnsweredLabel[];
+  onRemoveLabel: DraggableLabelToDroppableContProps['onRemoveLabel'];
 };
 
 const TransformContainer = styled(TransformWrapper)(() => ({
@@ -25,6 +27,7 @@ const DraggableFrameWithLabels = ({
   isDragging,
   labels,
   isSubmitted,
+  onRemoveLabel,
 }: Props): JSX.Element => (
   <Box sx={{ width: '100%' }}>
     <TransformContainer
@@ -36,16 +39,19 @@ const DraggableFrameWithLabels = ({
       alignmentAnimation={{ disabled: isDragging }}
       velocityAnimation={{ disabled: isDragging }}
     >
-      <TransformComponent
-        wrapperStyle={{
-          width: '100%',
-          maxHeight: '100%',
-        }}
-        contentStyle={{
-          width: '100%',
-        }}
+      <Box
+        width="100%"
+        position="relative"
+        id={LABELS_WITHIN_FRAME_CONTAINER_ID}
       >
-        <Box sx={{ width: '100%' }} id={LABELS_WITHIN_FRAME_CONTAINER_ID}>
+        <TransformComponent
+          wrapperStyle={{
+            width: '100%',
+          }}
+          contentStyle={{
+            width: '100%',
+          }}
+        >
           <ImageFrame />
           {labels.map((label, index) => (
             <DroppableLabel
@@ -53,11 +59,12 @@ const DraggableFrameWithLabels = ({
               label={label}
               key={label.expected.id}
               isDragging={isDragging}
+              onRemoveLabel={onRemoveLabel}
               isSubmitted={isSubmitted}
             />
           ))}
-        </Box>
-      </TransformComponent>
+        </TransformComponent>
+      </Box>
     </TransformContainer>
   </Box>
 );

--- a/src/modules/common/DraggableLabelToDroppableCont.tsx
+++ b/src/modules/common/DraggableLabelToDroppableCont.tsx
@@ -1,7 +1,9 @@
 import { Draggable } from 'react-beautiful-dnd';
 
-import { styled } from '@mui/material';
+import { Clear } from '@mui/icons-material';
+import { IconButton, Stack, styled } from '@mui/material';
 
+import { Label } from '@/@types';
 import { buildDraggableLabelId } from '@/config/selectors';
 
 export const StyledLabel = styled('div')<{
@@ -13,6 +15,7 @@ export const StyledLabel = styled('div')<{
   borderRadius: theme.spacing(1),
   border: '1px solid white',
   padding: theme.spacing(1),
+
   ...(isDraggable
     ? {
         background: 'purple',
@@ -27,38 +30,56 @@ export const StyledLabel = styled('div')<{
   }),
 }));
 
-type Props = {
+export type DraggableLabelToDroppableContProps = {
   index: number;
-  draggableId: string;
+  label: Label;
   content: string;
   isSubmitted?: boolean;
   isCorrect?: boolean;
+  /**
+   * whether the label can be dragged
+   * usually labels inside the frame, that are set as an answer
+   */
+  isDragDisabled?: boolean;
+  onRemoveLabel?: (label: Label) => void;
 };
 const DraggableLabelToDroppableCont = ({
-  draggableId,
+  label,
   index,
   content,
   isSubmitted = false,
   isCorrect,
-}: Props): JSX.Element => (
+  isDragDisabled,
+  onRemoveLabel,
+}: DraggableLabelToDroppableContProps): JSX.Element => (
   <Draggable
-    key={draggableId}
-    draggableId={draggableId}
+    key={label.id}
+    draggableId={label.id}
     index={index}
-    isDragDisabled={isSubmitted}
+    isDragDisabled={isDragDisabled}
   >
     {(dragProvided, dragSnapshot) => (
-      <StyledLabel
-        ref={dragProvided.innerRef}
-        {...dragProvided.draggableProps}
-        {...dragProvided.dragHandleProps}
-        isDraggable={dragSnapshot.isDragging}
-        isSubmitted={isSubmitted}
-        isCorrect={isCorrect}
-        id={buildDraggableLabelId(draggableId)}
-      >
-        {content}
-      </StyledLabel>
+      <Stack direction="row" alignItems="center">
+        <StyledLabel
+          ref={dragProvided.innerRef}
+          {...dragProvided.draggableProps}
+          {...dragProvided.dragHandleProps}
+          isDraggable={dragSnapshot.isDragging}
+          isSubmitted={isSubmitted}
+          isCorrect={isCorrect}
+          id={buildDraggableLabelId(label.id)}
+        >
+          {content}
+        </StyledLabel>
+        {isDragDisabled && (
+          <IconButton
+            sx={{ padding: 0 }}
+            onClick={() => onRemoveLabel?.(label)}
+          >
+            <Clear fontSize="small" />
+          </IconButton>
+        )}
+      </Stack>
     )}
   </Draggable>
 );

--- a/src/modules/common/DroppableLabel.tsx
+++ b/src/modules/common/DroppableLabel.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
 import { Droppable } from 'react-beautiful-dnd';
+import { useControls } from 'react-zoom-pan-pinch';
 
 import { styled } from '@mui/material';
 
 import { AnsweredLabel } from '@/@types';
 import { buildDraggableLabelId } from '@/config/selectors';
 
-import DraggableLabelToDroppableCont from './DraggableLabelToDroppableCont';
+import DraggableLabelToDroppableCont, {
+  DraggableLabelToDroppableContProps,
+} from './DraggableLabelToDroppableCont';
 
 export const Wrapper = styled('div')<{
   top: string;
@@ -41,6 +43,7 @@ type Props = {
   isDragging?: boolean;
   isSubmitted: boolean;
   index: number;
+  onRemoveLabel: DraggableLabelToDroppableContProps['onRemoveLabel'];
 };
 
 const DroppableLabel = ({
@@ -48,32 +51,40 @@ const DroppableLabel = ({
   isDragging,
   isSubmitted,
   index,
-}: Props): JSX.Element => (
-  <Droppable droppableId={label.expected.id} key={label.expected.id}>
-    {(provided, dropSnapshot) => (
-      <Wrapper
-        ref={provided.innerRef}
-        {...provided.droppableProps}
-        top={label.expected.y}
-        left={label.expected.x}
-        isFilled={Boolean(label.actual)}
-        isDraggingOver={dropSnapshot.isDraggingOver}
-        isDragging={isDragging}
-        id={buildDraggableLabelId(label.expected.id)}
-      >
-        {label.actual ? (
-          <DraggableLabelToDroppableCont
-            isCorrect={label.expected.id === label.actual?.id}
-            isSubmitted={isSubmitted}
-            content={label.actual.content}
-            index={index}
-            draggableId={label.actual.id}
-          />
-        ) : null}
-        {provided.placeholder}
-      </Wrapper>
-    )}
-  </Droppable>
-);
+  onRemoveLabel,
+}: Props): JSX.Element => {
+  // instance exists if within transform wrapper: inside frame
+  const { instance } = useControls();
+
+  return (
+    <Droppable droppableId={label.expected.id} key={label.expected.id}>
+      {(provided, dropSnapshot) => (
+        <Wrapper
+          ref={provided.innerRef}
+          {...provided.droppableProps}
+          top={label.expected.y}
+          left={label.expected.x}
+          isFilled={Boolean(label.actual)}
+          isDraggingOver={dropSnapshot.isDraggingOver}
+          isDragging={isDragging}
+          id={buildDraggableLabelId(label.expected.id)}
+        >
+          {label.actual ? (
+            <DraggableLabelToDroppableCont
+              isCorrect={label.expected.id === label.actual?.id}
+              isSubmitted={isSubmitted}
+              content={label.actual.content}
+              index={index}
+              label={label.actual}
+              isDragDisabled={Boolean(instance)}
+              onRemoveLabel={onRemoveLabel}
+            />
+          ) : null}
+          {provided.placeholder}
+        </Wrapper>
+      )}
+    </Droppable>
+  );
+};
 
 export default DroppableLabel;

--- a/src/modules/common/PlayerFrame.tsx
+++ b/src/modules/common/PlayerFrame.tsx
@@ -10,12 +10,14 @@ import { trackLabelsChanges } from '@/utils/dnd';
 
 import AllLabelsContainer from './AllLabelsContainer';
 import DraggableFrameWithLabels from './DraggableFrameWithLabels';
+import { DraggableLabelToDroppableContProps } from './DraggableLabelToDroppableCont';
 
 type Props = {
   labels: null | Label[];
   answeredLabels: AnsweredLabel[];
   isSubmitted?: boolean;
   onLabelMoved: (newLabels: Label[], newAnswers: AnsweredLabel[]) => void;
+  onRemoveLabel: DraggableLabelToDroppableContProps['onRemoveLabel'];
 };
 
 const PlayerFrame = ({
@@ -23,6 +25,7 @@ const PlayerFrame = ({
   answeredLabels,
   isSubmitted = false,
   onLabelMoved,
+  onRemoveLabel,
 }: Props): JSX.Element => {
   const { t } = useAppTranslation();
 
@@ -61,13 +64,7 @@ const PlayerFrame = ({
         onDragStart={() => setIsDragging(true)}
       >
         {labels && (
-          <Box
-            sx={{
-              position: 'relative',
-              marginBottom: 2,
-              width: '100%',
-            }}
-          >
+          <Box position="relative" mb={2}>
             <AllLabelsContainer labels={labels} isSubmitted={isSubmitted} />
           </Box>
         )}
@@ -75,6 +72,7 @@ const PlayerFrame = ({
           labels={answeredLabels}
           isDragging={isDragging}
           isSubmitted={isSubmitted}
+          onRemoveLabel={onRemoveLabel}
         />
       </DragDropContext>
     </Box>

--- a/src/modules/main/PlayerView.tsx
+++ b/src/modules/main/PlayerView.tsx
@@ -42,7 +42,7 @@ const PlayerView = (): JSX.Element => {
   const { mutate: postAppData } = mutations.usePostAppData();
   const { mutate: patchAppData } = mutations.usePatchAppData();
 
-  const { data: image } = hooks.useAppSettings({
+  const { data: image, isLoading: isImageLoading } = hooks.useAppSettings({
     name: SettingsKeys.File,
   });
 
@@ -185,7 +185,7 @@ const PlayerView = (): JSX.Element => {
     );
   }
 
-  if (isLoading) {
+  if (isLoading || isImageLoading) {
     return <CircularProgress />;
   }
 

--- a/src/modules/main/PlayerView.tsx
+++ b/src/modules/main/PlayerView.tsx
@@ -130,6 +130,27 @@ const PlayerView = (): JSX.Element => {
     saveAppData(submittedAnswers);
   };
 
+  const onRemoveLabel = (label: Label): void => {
+    if (lastSubmittedAnsweredLabels) {
+      const submittedAnswers = lastSubmittedAnsweredLabels.map((a) => {
+        const { expected, actual } = a;
+        if (actual?.id === label.id) {
+          return {
+            expectedId: expected.id,
+            actualId: null,
+          };
+        }
+
+        return {
+          expectedId: expected.id,
+          actualId: actual?.id,
+        };
+      });
+
+      saveAppData(submittedAnswers);
+    }
+  };
+
   if (config && image) {
     return (
       <Container data-cy={PLAYER_VIEW_CY}>
@@ -157,6 +178,7 @@ const PlayerView = (): JSX.Element => {
             isSubmitted={isSubmitted}
             answeredLabels={answeredLabels}
             onLabelMoved={onLabelMoved}
+            onRemoveLabel={onRemoveLabel}
           />
         </Stack>
       </Container>


### PR DESCRIPTION
I added a remove button, instead of dragging out the label if we want to remove it. This solves the offset problem we have because of the transform.

https://github.com/user-attachments/assets/6d32c2ab-5b01-49ff-b508-cc035b58ac0c


For some reason I can't load player data all the time, I think it's a problem with the mock.

 